### PR TITLE
remove Vue development warnings

### DIFF
--- a/vue-jest/package.json
+++ b/vue-jest/package.json
@@ -8,7 +8,7 @@
     "dev": "node build/dev-server.js",
     "build": "node build/build.js",
     "lint": "eslint --ext .js,.vue src",
-    "test": "./node_modules/.bin/jest"
+    "test": "NODE_ENV=production ./node_modules/.bin/jest"
   },
   "dependencies": {
     "vue": "^2.1.0"


### PR DESCRIPTION
Don't feel pressured to add this change, but is something that I add as the following warning will rise for each test and after a while it becomes just noise.

```
You are running Vue in development mode.
Make sure to turn on production mode when deploying for production.
See more tips at https://vuejs.org/guide/deployment.html
```
